### PR TITLE
Disable legacy v1 Backbone UI by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ You can do most of what you need to do with `neko` from the web interface, which
 Neko currently bundles three versions of the web interface for different preferences:
 
 *   **v3 (Vanilla javascripit)**: Default at / and at `/v3/`. A high-performance, zero-dependency version built for speed and simplicity. 
-*   **v1 (Legacy Backbone)**: Available at `/v1/`. The original classic interface I wrote before AI. It uses backbone and is included for historical record, I guess.
+*   **v1 (Legacy Backbone)**: The original classic interface I wrote before AI, kept for historical record. It bundles old jQuery/Backbone with known XSS advisories, so it is **disabled by default**. Enable it at `/v1/` with the `--legacy-ui` flag (or `legacy_ui: true` in the config file) only if you understand the risk.
 
 You can specify a different port using the `--http` option.
 
@@ -81,7 +81,34 @@ You can specify a different port using the `--http` option.
 If you are hosting on a publicly available server instead of a personal computer, you can protect the interface with a password flag --
 
     $ neko --password=rssisveryimportant
-    
+
+### Public Deployment Notes
+
+`neko` does not rate-limit login attempts itself. If you expose it on the
+public internet, run it behind a reverse proxy and add throttling there. With
+nginx, a few lines guard the login endpoints against brute force:
+
+```nginx
+# In the http {} block:
+limit_req_zone $binary_remote_addr zone=neko_login:10m rate=5r/m;
+
+server {
+    # ... your existing TLS / proxy config ...
+
+    location ~ ^/(login/|api/login) {
+        limit_req zone=neko_login burst=5 nodelay;
+        proxy_pass http://127.0.0.1:4994;
+    }
+
+    location / {
+        proxy_pass http://127.0.0.1:4994;
+    }
+}
+```
+
+When terminating TLS at the proxy, also pass `--secure-cookies` so the auth
+and CSRF cookies are only sent over HTTPS.
+
 ## Add Feed
 
 You can add feeds directly from the command line for convenience --
@@ -152,6 +179,7 @@ A subset of the command line options are supported in the configuration file, wi
    * minutes
    * password
    * secure_cookies
+   * legacy_ui
 
 For example --
 
@@ -162,6 +190,7 @@ imageproxy: true
 minutes: 90
 password: VeryLongRandomStringBecauseSecurityIsFun
 # secure_cookies: true  # Set to true when using HTTPS in production
+# legacy_ui: true       # Enable the old v1 Backbone UI at /v1/ (not recommended)
 
 ```
 ## Storage
@@ -209,6 +238,8 @@ Usage of neko:
     	minutes between crawling feeds (default -1, uses 60 if unset)
   -p, --password string
     	password to access web interface
+  --legacy-ui
+    	enable the legacy v1 Backbone web interface at /v1/ (disabled by default)
   --purge int
         purge read items older than N days
   --purge-unread

--- a/cmd/neko/main.go
+++ b/cmd/neko/main.go
@@ -28,7 +28,7 @@ func main() {
 }
 
 func Run(args []string) error {
-	var help, update, verbose, proxyImages, secureCookies bool
+	var help, update, verbose, proxyImages, secureCookies, legacyUI bool
 	var configFile, dbfile, newFeed, export, password string
 	var port, minutes int
 	var purge int
@@ -70,6 +70,8 @@ func Run(args []string) error {
 	f.BoolVar(&proxyImages, "i", false, "rewrite and proxy all image requests (short)")
 
 	f.BoolVar(&secureCookies, "secure-cookies", false, "set Secure flag on cookies (requires HTTPS)")
+
+	f.BoolVar(&legacyUI, "legacy-ui", false, "enable the legacy v1 Backbone web interface at /v1/")
 
 	f.BoolVar(&verbose, "verbose", false, "verbose output")
 	f.BoolVar(&verbose, "v", false, "verbose output (short)")
@@ -127,6 +129,10 @@ func Run(args []string) error {
 
 	if secureCookies {
 		config.Config.SecureCookies = secureCookies
+	}
+
+	if legacyUI {
+		config.Config.EnableLegacyUI = legacyUI
 	}
 
 	models.InitDB()

--- a/cmd/neko/main_test.go
+++ b/cmd/neko/main_test.go
@@ -151,6 +151,19 @@ func TestRunSecureCookies(t *testing.T) {
 	}
 }
 
+func TestRunLegacyUIFlag(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test_legacy.db")
+	config.Config.Port = -1
+	config.Config.EnableLegacyUI = false
+	err := Run([]string{"-d", dbPath, "-legacy-ui"})
+	if err != nil {
+		t.Errorf("Run -legacy-ui should succeed, got %v", err)
+	}
+	if !config.Config.EnableLegacyUI {
+		t.Error("Expected EnableLegacyUI to be true")
+	}
+}
+
 func TestRunMinutesFlag(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "test_minutes.db")
 	config.Config.Port = -1

--- a/config/config.go
+++ b/config/config.go
@@ -13,6 +13,7 @@ type Settings struct {
 	CrawlMinutes   int    `yaml:"minutes"`
 	ProxyImages    bool   `yaml:"imageproxy"`
 	SecureCookies  bool   `yaml:"secure_cookies"`
+	EnableLegacyUI bool   `yaml:"legacy_ui"`
 }
 
 var Config Settings

--- a/web/routing_test.go
+++ b/web/routing_test.go
@@ -11,6 +11,9 @@ import (
 
 func TestRouting(t *testing.T) {
 	config.Config.DigestPassword = "secret"
+	origLegacy := config.Config.EnableLegacyUI
+	config.Config.EnableLegacyUI = true // exercise the legacy /v1/ routes
+	defer func() { config.Config.EnableLegacyUI = origLegacy }()
 	router := NewRouter(&config.Config)
 
 	tests := []struct {
@@ -72,5 +75,49 @@ func TestRouting(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// The legacy v1 Backbone UI must NOT be served unless explicitly enabled,
+// since it ships old jQuery/Backbone with known XSS advisories. With the
+// route unmounted, /v1/ falls through to the v3 SPA catch-all — what matters
+// is that the vulnerable legacy ui.html is never returned.
+func TestLegacyUIDisabledByDefault(t *testing.T) {
+	config.Config.DigestPassword = "secret"
+	origLegacy := config.Config.EnableLegacyUI
+	config.Config.EnableLegacyUI = false
+	defer func() { config.Config.EnableLegacyUI = origLegacy }()
+
+	router := NewRouter(&config.Config)
+
+	req := httptest.NewRequest("GET", "/v1/", nil)
+	req.AddCookie(authCookie())
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	body := strings.ToLower(rr.Body.String())
+	if strings.Contains(body, "<title>neko rss mode</title>") {
+		t.Error("legacy backbone UI must not be served when EnableLegacyUI is false")
+	}
+}
+
+func TestLegacyUIEnabledWhenConfigured(t *testing.T) {
+	config.Config.DigestPassword = "secret"
+	origLegacy := config.Config.EnableLegacyUI
+	config.Config.EnableLegacyUI = true
+	defer func() { config.Config.EnableLegacyUI = origLegacy }()
+
+	router := NewRouter(&config.Config)
+
+	req := httptest.NewRequest("GET", "/v1/", nil)
+	req.AddCookie(authCookie())
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("legacy /v1/ should serve when enabled, got %d", rr.Code)
+	}
+	if !strings.Contains(strings.ToLower(rr.Body.String()), "<title>neko rss mode</title>") {
+		t.Error("expected legacy ui.html body when enabled")
 	}
 }

--- a/web/web.go
+++ b/web/web.go
@@ -275,8 +275,12 @@ func NewRouter(cfg *config.Settings) http.Handler {
 	// React Frontend (v2) at /v2/
 	mux.Handle("/v2/", GzipMiddleware(http.StripPrefix("/v2/", ServeFrontend("dist/v2"))))
 
-	// Legacy UI at /v1/
-	mux.Handle("/v1/", GzipMiddleware(http.StripPrefix("/v1/", AuthWrap(http.HandlerFunc(indexHandler)))))
+	// Legacy UI at /v1/ — disabled by default. It ships old bundled
+	// jQuery/Backbone with known XSS advisories, so it is only mounted
+	// when explicitly enabled via --legacy-ui / legacy_ui config.
+	if cfg.EnableLegacyUI {
+		mux.Handle("/v1/", GzipMiddleware(http.StripPrefix("/v1/", AuthWrap(http.HandlerFunc(indexHandler)))))
+	}
 
 	// New REST API
 	apiServer := api.NewServer(cfg)


### PR DESCRIPTION
The v1 UI bundles old jQuery/Backbone with known XSS advisories and is now only mounted at /v1/ when explicitly enabled via --legacy-ui (or legacy_ui: true in the config file). When disabled, /v1/ falls through to the v3 SPA so the vulnerable ui.html is never served.

Also documents that login is not rate-limited in-app and provides an nginx limit_req snippet for public deployments, rather than adding an in-app limiter (the reverse proxy sees the real client IP and avoids extra state).

Tests cover the default-off, opt-in, and flag-parsing behavior.